### PR TITLE
Remove textbox limit to allow full guild info importing

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -282,7 +282,6 @@ function popupConfig()
 		i = i + 1
 		textBuffer[i] = c
 	end)
-	inputfield.editBox:SetMaxBytes(2500)
 	inputfield.editBox:SetScript("OnMouseUp", nil);
 
 	inputfield:DisableButton(true)


### PR DESCRIPTION
I'm in a guild now with lots of wishlist/loot received data that needs to be imported into TMBHelper, but it's currently limited to 2500 characters at a time making the importing process painful. Not sure if there is another reason for this 2500 character limit, but removing it allows for a full guild import from TMB website